### PR TITLE
Fix typo in source file changed message

### DIFF
--- a/csvEditorHtml/browser/indexBrowser.html
+++ b/csvEditorHtml/browser/indexBrowser.html
@@ -947,7 +947,7 @@
 				<h3 class="title is-3">Source file changed</h3>
 
 				<p>
-					The source file changed, thus the tabel is not up-to-date. <br />
+					The source file changed, thus the table is not up-to-date. <br />
 					You can reload the file content which will discard all changes to the table! <br /><br />
 					Or you can ignore the changes. <br />
 					<br />

--- a/csvEditorHtml/browser/indexBrowserDebug.html
+++ b/csvEditorHtml/browser/indexBrowserDebug.html
@@ -941,7 +941,7 @@
 				<h3 class="title is-3">Source file changed</h3>
 
 				<p>
-					The source file changed, thus the tabel is not up-to-date. <br />
+					The source file changed, thus the table is not up-to-date. <br />
 					You can reload the file content which will discard all changes to the table! <br /><br />
 					Or you can ignore the changes. <br />
 					<br />

--- a/csvEditorHtml/index.html
+++ b/csvEditorHtml/index.html
@@ -752,7 +752,7 @@
 				<h3 class="title is-3">Source file changed</h3>
 
 				<p>
-					The source file changed, thus the tabel is not up-to-date. <br />
+					The source file changed, thus the table is not up-to-date. <br />
 					You can reload the file content which will discard all changes to the table! <br /><br />
 					Or you can ignore the changes. <br />
 					<br />

--- a/src/getHtml.ts
+++ b/src/getHtml.ts
@@ -824,7 +824,7 @@ export function createEditorHtml(webview: vscode.Webview, context: vscode.Extens
 				<h3 class="title is-3">Source file changed</h3>
 
 				<p>
-					The source file changed, thus the tabel is not up-to-date. <br />
+					The source file changed, thus the table is not up-to-date. <br />
 					You can reload the file content which will discard all changes to the table! <br /><br />
 					Or you can ignore the changes. <br />
 					<br />


### PR DESCRIPTION
Thanks for creating this handy VSCode extension! Fixed a minor typo (`tabel` => `table`) that I happened to notice in one of the messages from the extension.