### PR TITLE
Fix instance comparison

### DIFF
--- a/src/instanceManager.ts
+++ b/src/instanceManager.ts
@@ -114,7 +114,7 @@ export class InstanceManager {
 
 		//key is the source uri ... but we might change that so use find
 		// const instance = this.instances[sourceUri.toString()]
-		const instance = this.getAllInstances().find(p => p.sourceUri === sourceUri)
+		const instance = this.getAllInstances().find(p => p.sourceUri.path == sourceUri.path)
 
 		if (!instance) return null
 

--- a/src/instanceManager.ts
+++ b/src/instanceManager.ts
@@ -114,7 +114,7 @@ export class InstanceManager {
 
 		//key is the source uri ... but we might change that so use find
 		// const instance = this.instances[sourceUri.toString()]
-		const instance = this.getAllInstances().find(p => p.sourceUri.path == sourceUri.path)
+		const instance = this.getAllInstances().find(p => p.sourceUri.toString() == sourceUri.toString())
 
 		if (!instance) return null
 


### PR DESCRIPTION
How to replicate the bug:
1. Open a csv file, let's call it file.csv.
2. Click on "edit csv", editor will open.
3. Close the original file.csv.
4. Open file.csv again.
5. Click on "edit csv" there.
6. Error message will pop up in the bottom right and a second editor will try opening but will fail.

This is caused by comparison function used when finding instances. Comparing objects with === only checks for reference equality. If we open the same file twice then both uri objects will have the same content, but their references will be different. The fix in this PR makes it work by changing how uri objects are compared. Comparing path should do the job well enough, but if there is something I'm missing then using .toString() should fix the problem too.
